### PR TITLE
Modificação UcConsts_Language.pas

### DIFF
--- a/source/UcConsts_Language.pas
+++ b/source/UcConsts_Language.pas
@@ -1,4 +1,6 @@
 unit UcConsts_Language;
+ 
+ {$codepage UTF8} //Converte o código para UTF8 
 
 {$IFDEF FPC}
   {$MODE Delphi}


### PR DESCRIPTION
Inserido o código de conversão para literais normais de String por padrão.

Quando executava o demo o Lazarus não entendia a acentuação Português Brasil, por isso inseri a literal {$codepage UTF8} para o compilador entender que aquele código é UTF8.